### PR TITLE
Add default security config

### DIFF
--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/config/BaseSecurity.java
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/config/BaseSecurity.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+package ch.admin.bag.covidcertificate.backend.delivery.ws.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+/**
+ * Inject this security config, to overrule the default spring boot security config which
+ * goes into complete lock down.
+ * 
+ * We further deactivate csrf, since we are not serving any HTML/Frontend content but only serve
+ * as an API-Server
+ */
+@Configuration
+
+@Order(10000)
+public class BaseSecurity extends WebSecurityConfigurerAdapter {
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.csrf().disable();
+    }
+}


### PR DESCRIPTION
We add a default `SecurityConfig` to the end of the chain, since as soon as the spring-boot-security-config is added as a dependency, a default config which denies any request is added.

Further, we deactivate CSRF for all requests, since all requests to the API come either from backend-clients, or are authenticated via a signature scheme.