### PR TITLE
validate rsa key min length (2048)

### DIFF
--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/security/encryption/Crypto.java
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/security/encryption/Crypto.java
@@ -34,7 +34,7 @@ public abstract class Crypto {
             throws NoSuchPaddingException, NoSuchAlgorithmException,
                     InvalidAlgorithmParameterException, InvalidKeyException,
                     IllegalBlockSizeException, BadPaddingException, InvalidKeySpecException,
-                    InvalidParameterSpecException;
+                    InvalidParameterSpecException, InvalidPublicKeyException;
 
     /**
      * validates the signature and signature payload with the given public key
@@ -73,5 +73,6 @@ public abstract class Crypto {
     protected abstract Signature getSignature() throws NoSuchAlgorithmException;
 
     protected abstract PublicKey getPublicKey(String publicKey)
-            throws NoSuchAlgorithmException, InvalidKeySpecException, InvalidParameterSpecException;
+            throws NoSuchAlgorithmException, InvalidKeySpecException, InvalidParameterSpecException,
+                    InvalidPublicKeyException;
 }

--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/test/java/ch/admin/bag/covidcertificate/backend/delivery/ws/security/encryption/CryptoHelper.java
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/test/java/ch/admin/bag/covidcertificate/backend/delivery/ws/security/encryption/CryptoHelper.java
@@ -16,8 +16,12 @@ public class CryptoHelper {
     }
 
     public static KeyPair createRsaKeyPair() throws NoSuchAlgorithmException {
+        return createRsaKeyPair(2048);
+    }
+
+    public static KeyPair createRsaKeyPair(int keyLength) throws NoSuchAlgorithmException {
         var kpg = KeyPairGenerator.getInstance("RSA");
-        kpg.initialize(2048);
+        kpg.initialize(keyLength);
         return kpg.generateKeyPair();
     }
 

--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/test/java/ch/admin/bag/covidcertificate/backend/delivery/ws/security/encryption/CryptoTest.java
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/test/java/ch/admin/bag/covidcertificate/backend/delivery/ws/security/encryption/CryptoTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import ch.admin.bag.covidcertificate.backend.delivery.data.util.CodeGenerator;
 import ch.admin.bag.covidcertificate.backend.delivery.model.app.Algorithm;
 import ch.admin.bag.covidcertificate.backend.delivery.ws.security.Action;
+import ch.admin.bag.covidcertificate.backend.delivery.ws.security.exception.InvalidPublicKeyException;
 import ch.admin.bag.covidcertificate.backend.delivery.ws.security.exception.InvalidSignatureException;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -90,6 +91,13 @@ public class CryptoTest {
 
         String pubKey = Base64.getEncoder().encodeToString(rsaKeyPair.getPublic().getEncoded());
         printPayloads(sig, CODE, pubKey, Algorithm.RSA2048);
+    }
+
+    @Test
+    public void shortRsaKey() throws Exception {
+        KeyPair rsaKeyPair = CryptoHelper.createRsaKeyPair(2000);
+        String pubKey = Base64.getEncoder().encodeToString(rsaKeyPair.getPublic().getEncoded());
+        assertThrows(InvalidPublicKeyException.class, () -> new RsaCrypto().getPublicKey(pubKey));
     }
 
     private void printPayloads(Signature sig, String code, String pubKey, Algorithm algorithm)


### PR DESCRIPTION
this pull request adds rsa key length validation. only rsa keys with a length >= 2048 are accepted