### PR TITLE
explicit http status code for invalid timestamp (signaturePayload)

### DIFF
--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/config/WsBaseConfig.java
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/config/WsBaseConfig.java
@@ -28,6 +28,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
@@ -111,8 +112,10 @@ public abstract class WsBaseConfig implements WebMvcConfigurer {
     }
 
     @Bean
-    public SignaturePayloadValidator signatureValidator() {
-        return new SignaturePayloadValidator();
+    public SignaturePayloadValidator signatureValidator(
+            @Value("${ws.signature.validation.timestamp.halfWindowDuration:PT60M}")
+                    Duration halfWindow) {
+        return new SignaturePayloadValidator(halfWindow);
     }
 
     @Bean

--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/security/SignaturePayloadValidator.java
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/security/SignaturePayloadValidator.java
@@ -3,22 +3,27 @@ package ch.admin.bag.covidcertificate.backend.delivery.ws.security;
 import ch.admin.bag.covidcertificate.backend.delivery.model.util.CodeHelper;
 import ch.admin.bag.covidcertificate.backend.delivery.ws.security.exception.InvalidActionException;
 import ch.admin.bag.covidcertificate.backend.delivery.ws.security.exception.InvalidSignaturePayloadException;
+import ch.admin.bag.covidcertificate.backend.delivery.ws.security.exception.InvalidTimestampException;
+import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 
 public class SignaturePayloadValidator {
+    private final Duration halfWindow;
+
+    public SignaturePayloadValidator(Duration halfWindow) {
+        this.halfWindow = halfWindow;
+    }
 
     public void validate(String signaturePayload, Action expectedAction, String code)
-            throws InvalidSignaturePayloadException, InvalidActionException {
+            throws InvalidSignaturePayloadException, InvalidActionException,
+                    InvalidTimestampException {
         String[] signaturePayloadSplit = signaturePayload.split(":");
 
         if (signaturePayloadSplit.length != 3) {
             throw new InvalidSignaturePayloadException();
         }
 
-        if (!isCurrentTimestamp(Long.valueOf(signaturePayloadSplit[2]))) {
-            throw new InvalidSignaturePayloadException();
-        }
+        validateTimestamp(Long.valueOf(signaturePayloadSplit[2]));
 
         if (!code.equals(CodeHelper.getSanitizedCode(signaturePayloadSplit[1]))) {
             throw new InvalidSignaturePayloadException();
@@ -29,10 +34,11 @@ public class SignaturePayloadValidator {
         }
     }
 
-    private boolean isCurrentTimestamp(Long epochMilli) {
+    private void validateTimestamp(Long epochMilli) throws InvalidTimestampException {
         Instant now = Instant.now();
         Instant timestamp = Instant.ofEpochMilli(epochMilli);
-        return timestamp.isAfter(now.minus(5, ChronoUnit.MINUTES))
-                && timestamp.isBefore(now.plus(5, ChronoUnit.MINUTES));
+        if (timestamp.isBefore(now.minus(halfWindow)) || timestamp.isAfter(now.plus(halfWindow))) {
+            throw new InvalidTimestampException(now, halfWindow, timestamp);
+        }
     }
 }

--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/security/exception/InvalidTimestampException.java
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/security/exception/InvalidTimestampException.java
@@ -1,0 +1,28 @@
+package ch.admin.bag.covidcertificate.backend.delivery.ws.security.exception;
+
+import java.time.Duration;
+import java.time.Instant;
+
+public class InvalidTimestampException extends Exception {
+    private final Instant acceptedFrom;
+    private final Instant acceptedTo;
+    private final Instant actual;
+
+    public InvalidTimestampException(Instant now, Duration halfWindow, Instant timestamp) {
+        this.acceptedFrom = now.minus(halfWindow);
+        this.acceptedTo = now.plus(halfWindow);
+        this.actual = timestamp;
+    }
+
+    @Override
+    public String toString() {
+        return "InvalidTimestampException{"
+                + "acceptedFrom="
+                + acceptedFrom
+                + ", acceptedTo="
+                + acceptedTo
+                + ", actual="
+                + actual
+                + '}';
+    }
+}


### PR DESCRIPTION
this pull request adds:
- an explicit http status code for invalid timestamps
- specific http status codes for all app requests
- configurable accepted timestamp range
- logs for invalid timestamps