### PR TITLE
Extend transfer code validity to 30 days

### DIFF
--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/config/SchedulingConfig.java
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/config/SchedulingConfig.java
@@ -21,7 +21,7 @@ public class SchedulingConfig {
     private final IosHeartbeatSilentPush iosHeartbeatSilentPush;
     private final DeliveryDataService deliveryDataService;
 
-    @Value("${db.retentionPeriod:P10D}")
+    @Value("${db.retentionPeriod:P30D}")
     private Duration retentionPeriod;
 
     public SchedulingConfig(

--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/resources/application.properties
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/resources/application.properties
@@ -15,6 +15,8 @@ server.error.whitelabel.enabled=true
 
 jeap.logging.logrelay.host=logrelaycaasp.bit.admin.ch
 
+db.retentionPeriod=P30D
+
 #-------------------------------------------------------------------------------
 # JDBC Config
 #-------------------------------------------------------------------------------

--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/resources/application.properties
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/resources/application.properties
@@ -15,8 +15,6 @@ server.error.whitelabel.enabled=true
 
 jeap.logging.logrelay.host=logrelaycaasp.bit.admin.ch
 
-db.retentionPeriod=P30D
-
 #-------------------------------------------------------------------------------
 # JDBC Config
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Simple config changes to keep transfer codes in DB for 30 days