### PR TITLE
Spread out iOS silent pushes

### DIFF
--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-data/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/data/DeliveryDataService.java
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-data/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/data/DeliveryDataService.java
@@ -12,6 +12,7 @@ import ch.admin.bag.covidcertificate.backend.delivery.model.db.DbTransfer;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,14 +36,21 @@ public interface DeliveryDataService {
     public void upsertPushRegistration(PushRegistration registration);
 
     @Transactional(readOnly = false)
+    void updateLastPushTImes(Collection<PushRegistration> registrations);
+
+    @Transactional(readOnly = false)
     void removeRegistration(String registerId);
 
     void removeRegistrations(List<String> tokensToRemove);
 
     List<PushRegistration> getPushRegistrationByType(PushType pushType, int prevMaxId);
 
+    List<PushRegistration> getDuePushRegistrations(PushType pushType, Duration timeSinceLastPush, int limit);
+
     public void insertCovidCert(DbCovidCert covidCert);
 
     @Transactional(readOnly = false)
     void cleanDB(Duration retentionPeriod);
+
+    public int countRegistrations();
 }

--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-data/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/data/mapper/PushRegistrationRowMapper.java
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-data/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/data/mapper/PushRegistrationRowMapper.java
@@ -15,6 +15,9 @@ public class PushRegistrationRowMapper implements RowMapper<PushRegistration> {
         pushRegistration.setPushType(PushType.valueOf(rs.getString("push_type")));
         pushRegistration.setRegisterId(rs.getString("register_id"));
         pushRegistration.setId(rs.getInt("pk_push_registration_id"));
+        if(rs.getTimestamp("last_push") != null){
+            pushRegistration.setLastPush(rs.getTimestamp("last_push").toInstant());
+        }
         return pushRegistration;
     }
 }

--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-data/src/main/resources/db/migration/pgsql/V0_7__last_push.sql
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-data/src/main/resources/db/migration/pgsql/V0_7__last_push.sql
@@ -1,0 +1,1 @@
+alter table t_push_registration add column last_push timestamp with time zone;

--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-data/src/main/resources/db/migration/pgsql_cluster/V0_7__last_push.sql
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-data/src/main/resources/db/migration/pgsql_cluster/V0_7__last_push.sql
@@ -1,0 +1,1 @@
+alter table t_push_registration add column last_push timestamp with time zone;

--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-model/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/model/app/PushRegistration.java
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-model/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/model/app/PushRegistration.java
@@ -2,6 +2,7 @@ package ch.admin.bag.covidcertificate.backend.delivery.model.app;
 
 import ch.ubique.openapi.docannotations.Documentation;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.time.Instant;
 import javax.validation.constraints.NotNull;
 
 public class PushRegistration {
@@ -11,6 +12,7 @@ public class PushRegistration {
     @NotNull private PushType pushType;
     @NotNull private String registerId;
     @JsonIgnore private int id;
+    @JsonIgnore private Instant lastPush;
 
     public String getPushToken() {
         return pushToken;
@@ -42,5 +44,13 @@ public class PushRegistration {
 
     public void setRegisterId(String registerId) {
         this.registerId = registerId;
+    }
+
+    public Instant getLastPush() {
+        return lastPush;
+    }
+
+    public void setLastPush(Instant lastPush) {
+        this.lastPush = lastPush;
     }
 }

--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/config/SchedulingConfig.java
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/config/SchedulingConfig.java
@@ -30,7 +30,7 @@ public class SchedulingConfig {
     @Value("${push.schedulerInterval:PT10m}")
     private Duration pushScheduleInterval;
 
-    @Value("${push.batchSize:100000}")
+    @Value("${push.batchSize:10000}")
     private int pushBatchSize;
 
 

--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/service/IosHeartbeatSilentPush.java
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/service/IosHeartbeatSilentPush.java
@@ -1,5 +1,15 @@
 package ch.admin.bag.covidcertificate.backend.delivery.ws.service;
 
+import java.time.Duration;
+
 public interface IosHeartbeatSilentPush {
-    public void sendHeartbeats();
+    public void sendHeartbeats(Duration pushInterval, int pushLimit);
+
+    public void checkPushSchedule(Duration pushInterval, Duration pushSchedule, int batchSize);
+
+    static float calculatePushLoadFactor(Duration pushInterval, Duration pushSchedule, int batchSize, int numRegistrations){
+        float pushesPerPeriod = pushInterval.dividedBy(pushSchedule) * (float) batchSize;
+        float loadFactor = numRegistrations/pushesPerPeriod;
+        return loadFactor;
+    }
 }

--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/service/IosHeartbeatSilentPushImpl.java
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/service/IosHeartbeatSilentPushImpl.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -89,30 +90,33 @@ public class IosHeartbeatSilentPushImpl implements IosHeartbeatSilentPush {
         }
     }
 
-    public void sendHeartbeats() {
+    public void sendHeartbeats(Duration pushInterval, int pushLimit) {
         logger.info("Send iOS heartbeat push");
-        logger.info("Load tokens from database batch-wise.");
+        logger.info("Load batch of tokens from database");
         for (PushType pushType : PushType.values()) {
-            var maxId = 0;
-            var nextMaxId = 0;
-            List<PushRegistration> registrationList;
-            var done = false;
-            do {
-                done = true;
-                registrationList =
-                        pushRegistrationDataService.getPushRegistrationByType(pushType, maxId);
-                logger.info("Found {} {} push tokens", registrationList.size(), pushType);
-                if (!registrationList.isEmpty()) {
-                    done = false;
-                    Set<String> pushTokens = new HashSet<>();
-                    nextMaxId = registrationsToTokens(registrationList, pushTokens);
-                    sendPushNotificationsBatch(pushTokens, pushType);
-                }
-                maxId = nextMaxId;
-            } while (!done);
+            List <PushRegistration> registrationList =
+                pushRegistrationDataService.getDuePushRegistrations(pushType, pushInterval, pushLimit);//TODO make configurable
+            logger.info("Retrieved {} {} push tokens", registrationList.size(), pushType);
+            Set<String> pushTokens = new HashSet<>();
+            registrationsToTokens(registrationList, pushTokens);
+            sendPushNotificationsBatch(pushTokens, pushType);
+            pushRegistrationDataService.updateLastPushTImes(registrationList);
         }
         logger.info("iOS hearbeat push done");
     }
+
+    @Override
+    public void checkPushSchedule(Duration pushInterval, Duration pushSchedule, int batchSize) {
+        float loadFactor = IosHeartbeatSilentPush.calculatePushLoadFactor(pushInterval, pushSchedule, batchSize, pushRegistrationDataService.countRegistrations());
+        if(loadFactor > 0.8){
+            logger.warn("iOS silent push schedule is about to overflow. Consider increasing batch sie or scheduler frequency. Load factor (overflow at 1.0): {}", loadFactor);
+        }else if(loadFactor >= 1.0){
+            logger.error("iOS silent pushes can no longer be delivered with this schedule. Increase batch size or frequency. Load factor: {}", loadFactor);
+        }else{
+            logger.info("iOS silent push schedule checked successfully. Load factor: {}", loadFactor);
+        }
+    }
+
 
     /**
      * Helper function to fill the push tokens from the list of push registrations into a separate

--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/service/IosHeartbeatSilentPushImpl.java
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/service/IosHeartbeatSilentPushImpl.java
@@ -95,7 +95,7 @@ public class IosHeartbeatSilentPushImpl implements IosHeartbeatSilentPush {
         logger.info("Load batch of tokens from database");
         for (PushType pushType : PushType.values()) {
             List <PushRegistration> registrationList =
-                pushRegistrationDataService.getDuePushRegistrations(pushType, pushInterval, pushLimit);//TODO make configurable
+                pushRegistrationDataService.getDuePushRegistrations(pushType, pushInterval, pushLimit);
             logger.info("Retrieved {} {} push tokens", registrationList.size(), pushType);
             Set<String> pushTokens = new HashSet<>();
             registrationsToTokens(registrationList, pushTokens);

--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/service/MockIosHeartBeatSilentPush.java
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/service/MockIosHeartBeatSilentPush.java
@@ -1,11 +1,18 @@
 package ch.admin.bag.covidcertificate.backend.delivery.ws.service;
 
+import java.time.Duration;
+
 public class MockIosHeartBeatSilentPush implements IosHeartbeatSilentPush {
 
     public MockIosHeartBeatSilentPush() {}
 
     @Override
-    public void sendHeartbeats() {
+    public void sendHeartbeats(Duration pushInterval, int pushLimit) {
+        // do nothing
+    }
+
+    @Override
+    public void checkPushSchedule(Duration pushInterval, Duration pushSchedule, int batchSize) {
         // do nothing
     }
 }

--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/test/java/ch/admin/bag/covidcertificate/backend/delivery/ws/util/IosHeartBeatSilentPushTest.java
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/test/java/ch/admin/bag/covidcertificate/backend/delivery/ws/util/IosHeartBeatSilentPushTest.java
@@ -1,0 +1,17 @@
+package ch.admin.bag.covidcertificate.backend.delivery.ws.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import ch.admin.bag.covidcertificate.backend.delivery.ws.service.IosHeartbeatSilentPush;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+public class IosHeartBeatSilentPushTest {
+  @Test
+  public void checkLoadFactorCalculation(){
+    //our current schedule can handle 2.4mio registrations
+    assertEquals(1.0, IosHeartbeatSilentPush.calculatePushLoadFactor(Duration.ofHours(2), Duration.ofMinutes(5), 100000, 2400000), 0.001);
+    assertEquals(0.8, IosHeartbeatSilentPush.calculatePushLoadFactor(Duration.ofHours(2), Duration.ofMinutes(5), 100000, 1920000),0.001);
+    assertEquals(2.0, IosHeartbeatSilentPush.calculatePushLoadFactor(Duration.ofHours(2), Duration.ofMinutes(5), 100000, 4800000), 0.001);
+  }
+}


### PR DESCRIPTION
iOS silent pushes are now done in smaller configurable batches rather than every hour.  

:warning: contains a DB migration

New config parameters:  
`push.pushInterval` The interval in which a client should receive a push (default every 2h)   
`push.pushInterval` How often the backend initiates a batch push (default every 10m)  
`push.batchSize` How many pushes are executed in one batch (100000)  

If the parameters are not sufficient to ensure clients are pushed regularly, an error is logged.