### PR TITLE
reduce log level for timestamp exception

### DIFF
--- a/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/controller/AppController.java
+++ b/ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/src/main/java/ch/admin/bag/covidcertificate/backend/delivery/ws/controller/AppController.java
@@ -228,7 +228,7 @@ public class AppController {
     @ExceptionHandler({InvalidTimestampException.class})
     @ResponseStatus(HttpStatus.TOO_EARLY)
     public ResponseEntity<String> invalidTimestamp(InvalidTimestampException e) {
-        logger.error("received invalid timestamp. {}", e.toString());
+        logger.warn("received invalid timestamp. {}", e.toString());
         return ResponseEntity.status(HttpStatus.TOO_EARLY).body("I | TIME");
     }
 


### PR DESCRIPTION
The handling of the TimestampException in the app controller that was causing log spam has been reduced to a warning