### PR TITLE
tag prereleases on github

### DIFF
--- a/.github/workflows/tagged_release.yaml
+++ b/.github/workflows/tagged_release.yaml
@@ -32,7 +32,7 @@ jobs:
       uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        prerelease: false
+        prerelease: ${{ contains(github.ref, 'prerelease') }}
         files: |
           ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/target/ch-covidcertificate-backend-delivery-ws.jar
           ch-covidcertificate-backend-delivery/ch-covidcertificate-backend-delivery-ws/target/ch-covidcertificate-backend-delivery-ws.jar.sha256


### PR DESCRIPTION
Correctly sets the prerelease tag in the action that creates a Github release